### PR TITLE
Acquire a single device with sair-acquire --count 1

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,7 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SAIR_API_KEY: op://Infrastructure/sair-api-key/credential
+          SAIR_API_KEY: op://Infrastructure/sair-user-api-key/credential
 
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,10 +41,14 @@ jobs:
         run: ./gradlew testDebugUnitTest
 
       - name: Install SAIR tools
-        run: curl -fsSL https://raw.githubusercontent.com/compscidr/sair/v0.0.3/install.sh | bash
+        run: curl -fsSL https://raw.githubusercontent.com/compscidr/sair/v0.0.12/install.sh | bash
 
+      # Capture output in a variable rather than piping, so a sair-acquire
+      # failure fails this step instead of being masked by sed's exit code.
       - name: Acquire device lock
-        run: sair-acquire | sed 's/^export //' >> $GITHUB_ENV
+        run: |
+          ACQUIRE_OUTPUT=$(sair-acquire --count 1)
+          echo "$ACQUIRE_OUTPUT" | sed -n 's/^export //p' >> "$GITHUB_ENV"
 
       - name: Clean Packages
         run: bash ./scripts/clean-packages.sh


### PR DESCRIPTION
Bumps the SAIR tools pin from v0.0.3 to [v0.0.12](https://github.com/compscidr/sair/releases/tag/v0.0.12) and switches device acquisition to `--count 1`, locking any one free device instead of the tenant's whole pool. With a single device locked, `sair-acquire` sets `ANDROID_SERIAL`, so adb and `connectedCheck` target just that device.

Also hardens the acquire step: output is captured in a variable rather than piped, so a failed `sair-acquire` fails the step instead of being masked by `sed`'s exit code, and only `export` lines are written to `GITHUB_ENV`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)