### PR TITLE
Bump compileSdk to 35

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'jacoco'
 apply plugin: 'checkstyle'
 
 android {
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         testInstrumentationRunnerArguments runnerBuilder: 'de.mannodermaus.junit5.AndroidJUnit5Builder'


### PR DESCRIPTION
Partially unblocks #454 (material 1.14.0), which fails `:app:checkDebugAarMetadata`:

> Dependency `androidx.core:core-ktx:1.16.0` requires libraries and applications that depend on it to compile against version 35 or later of the Android APIs. `:app` is currently compiled against android-34.

`androidx.core` 1.16.0 comes in transitively via material 1.14.0.

`minSdk` and `targetSdk` are untouched here — material 1.14.0 also needs `minSdk 23`, which is a separate judgement call and gets its own PR.

Verified locally: `./gradlew build app:lint testDebugUnitTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)