### PR TITLE
Hold junit-bom on 5.x

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,6 +78,8 @@ dependencies {
     implementation 'androidx.test:core:1.7.0'
 
     // Unit tests
+    // Pinned to 5.x: on JUnit 6 the android-junit5 runner requires API 35+ and disables all
+    // Jupiter instrumented tests below it. See renovate.json. Revisit when all test devices are API 35+.
     testImplementation platform("org.junit:junit-bom:5.14.4")
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
@@ -85,6 +87,7 @@ dependencies {
     testImplementation "org.mockito:mockito-junit-jupiter:5.23.0"
 
     // Instrumentation tests
+    // Pinned to 5.x — see note above.
     androidTestImplementation platform("org.junit:junit-bom:5.14.4")
     androidTestImplementation "org.junit.jupiter:junit-jupiter-api"
     androidTestImplementation "de.mannodermaus.junit5:android-test-core:2.0.1"

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,11 @@
       "description": "Pin ByteBuddy to avoid Jacoco transform conflicts",
       "matchPackageNames": ["net.bytebuddy:byte-buddy", "net.bytebuddy:byte-buddy-agent"],
       "enabled": false
+    },
+    {
+      "description": "Hold junit-bom on 5.x: the android-junit5 runner refuses to run Jupiter instrumented tests below API 35 on JUnit 6, which would drop on-device coverage for every device older than Android 15. Revisit when the device farm is all API 35+.",
+      "matchPackageNames": ["org.junit:junit-bom"],
+      "allowedVersions": "<6"
     }
   ]
 }


### PR DESCRIPTION
Mirrors compscidr/hello-kotlin-android#494.

On JUnit 6 the `android-junit5` runner requires API 35+ and silently disables every Jupiter instrumented test below it — that would drop on-device coverage for every device older than Android 15. Not an acceptable trade for a version bump.

- `renovate.json`: `allowedVersions: "<6"` on `org.junit:junit-bom`, so #457 and its successors stop being proposed.
- `app/build.gradle`: a comment at each of the two `junit-bom` declarations explaining why the version is held, so the next person doesn't "helpfully" bump it.

Reverses course on the earlier reasoning in #480 — the junit-bom major ignore was there for a reason after all, though this cap is the more explicit way to express it.

Verified locally: `./gradlew build testDebugUnitTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)