### PR TITLE
Use shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,11 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>compscidr/renovate-config:android-junit5"],
   "packageRules": [
-    {
-      "description": "Automerge non-major updates",
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
-    },
     {
       "description": "Pin ByteBuddy to avoid Jacoco transform conflicts",
       "matchPackageNames": ["net.bytebuddy:byte-buddy", "net.bytebuddy:byte-buddy-agent"],
       "enabled": false
-    },
-    {
-      "description": "Hold junit-bom on 5.x: the android-junit5 runner refuses to run Jupiter instrumented tests below API 35 on JUnit 6, which would drop on-device coverage for every device older than Android 15. Revisit when the device farm is all API 35+.",
-      "matchPackageNames": ["org.junit:junit-bom"],
-      "allowedVersions": "<6"
     }
   ]
 }


### PR DESCRIPTION
Points this repo at the new [compscidr/renovate-config](https://github.com/compscidr/renovate-config) presets.

The inline automerge rule and the `junit-bom < 6` hold both move into the shared presets, so the JUnit 6 / API 35 reasoning lives in exactly one place instead of being copy-pasted per repo. `:android-junit5` is the right level here because this repo uses the `de.mannodermaus.junit5` instrumented-test runner.

The `android` preset underneath it also tracks `compileSdk` against the latest released Android API level, which stops androidx bumps from failing `checkAarMetadata` across every open Renovate PR at once.

### Verified

`renovate --platform=local --dry-run` with these presets resolved the full chain from GitHub and extracted `compileSdk` from both Kotlin DSL (`compileSdk = 37`) and Groovy (`compileSdk 35`) files. From behind, it proposed `newValue: 37` as `updateType: major`, so it will not slip through the minor/patch automerge.

### Kept locally

The ByteBuddy / Jacoco transform pin. Note this repo is on `compileSdk 35`, so expect a `compileSdk` PR shortly after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)